### PR TITLE
chore: update GitHub runners version

### DIFF
--- a/runners/Containerfile
+++ b/runners/Containerfile
@@ -1,7 +1,7 @@
 ## --- Actions Runner Dist
 FROM alpine AS runner-dist
 # renovate: datasource=github-releases depName=actions/runner
-ARG RUNNER_VERSION=2.321.0
+ARG RUNNER_VERSION=2.323.0
 # renovate: datasource=github-releases depName=actions/runner-container-hooks
 ARG RUNNER_CONTAINER_HOOKS_VERSION=0.6.2
 #


### PR DESCRIPTION
To the latest one from the https://github.com/actions/runner repo, the renovate bot didn't do that for us